### PR TITLE
feat: added support for azuredevops server endpoints

### DIFF
--- a/chart/crds/azuredevops.krateo.io_connectorconfigs.yaml
+++ b/chart/crds/azuredevops.krateo.io_connectorconfigs.yaml
@@ -38,8 +38,23 @@ spec:
           spec:
             properties:
               apiUrl:
-                description: 'ApiUrl: the baseUrl for the REST API provider.'
+                description: 'DEPRECATED: This field is deprecated and will be removed
+                  in a future version. Use the ApiUrls field instead. ApiUrl: the
+                  baseUrl for the REST API provider.'
                 type: string
+              apiUrls:
+                description: 'ApiUrls: the baseUrl for the REST API provider.'
+                properties:
+                  default:
+                    description: 'Default: the baseUrl for the REST API provider.'
+                    type: string
+                  feeds:
+                    description: 'Feeds: the baseUrl for the REST API provider.'
+                    type: string
+                  vssps:
+                    description: 'Vssps: the baseUrl for the REST API provider.'
+                    type: string
+                type: object
               credentials:
                 description: Credentials required to authenticate ReST API server.
                 properties:

--- a/chart/samples/connector-config.yaml
+++ b/chart/samples/connector-config.yaml
@@ -3,7 +3,11 @@ kind: ConnectorConfig
 metadata:
   name: connectorconfig-sample
 spec:
-  apiUrl: https://dev.azure.com
+  apiUrl: https://dev.azure.com # DEPRECATED - use apiUrls instead
+  apiUrls: 
+    default: https://dev.azure.com
+    feeds: https://feeds.dev.azure.com
+    vssps: https://vssps.dev.azure.com
   credentials:
     secretRef:
       namespace: default


### PR DESCRIPTION
Support for Azure DevOps server endpoints different from the cloud defaults has been added. If the apiUrls field is not set, Azure DevOps cloud endpoints are used by default.
The apiUrl field is deprecated. It was previously unused because cloud server endpoints were hardcoded. Setting this field does not alter the functionality of the provider and will be removed in future versions.